### PR TITLE
Patch Parser.php for PHP 8.2 and higher

### DIFF
--- a/src/Data.php
+++ b/src/Data.php
@@ -15,6 +15,7 @@ namespace JamesGordo\CSV;
  * @version  1.0.0
  */
 
+#[\AllowDynamicProperties]
 class Data
 {
     /**


### PR DESCRIPTION
Prohibiting the generation of notifications about the deprecation of objects of the library class using the example of the error: "Creation of dynamic property JamesGordo\CSV\Data::$id is deprecated"(https://habr.com/ru/companies/otus/articles/678176 /)